### PR TITLE
fix: for Raw queries avoid converting the input parameters passed

### DIFF
--- a/src/dialects/oracle/query.js
+++ b/src/dialects/oracle/query.js
@@ -121,6 +121,8 @@ export class OracleQuery extends AbstractQuery {
         bindDef.push(...Object.values(this.options.inbindAttributes));
         bindDef.push(...outParameters);
         this.bindParameters = parameters;
+      } else if (this.isRawQuery()) {
+        this.bindParameters = parameters;
       } else {
         Object.values(parameters).forEach(value => {
           bindParameters.push(value);


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

There were conversions for input bind values done for Raw Queries. It is not required for Raw Queries . Hence skipped it. 

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
