### PR TITLE
feat(oracle): support lock feature 

### DIFF
--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -28,8 +28,9 @@ OracleDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   'VALUES ()': true,
   'LIMIT ON UPDATE': true,
   IGNORE: ' IGNORE',
-  lock: false,
-  forShare: ' IN SHARE MODE',
+  lock: true,
+  lockOuterJoinFailure: true,
+  forShare: ' FOR UPDATE',
   index: {
     collate: false,
     length: false,

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -31,6 +31,7 @@ OracleDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   lock: true,
   lockOuterJoinFailure: true,
   forShare: ' FOR UPDATE',
+  skipLocked: true,
   index: {
     collate: false,
     length: false,

--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -30,7 +30,7 @@ OracleDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   IGNORE: ' IGNORE',
   lock: true,
   lockOuterJoinFailure: true,
-  forShare: ' FOR UPDATE',
+  forShare: 'FOR UPDATE',
   skipLocked: true,
   index: {
     collate: false,

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -28,6 +28,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       if (current.dialect.supports.lock) {
         it('findOrCreate supports transactions, json and locks', async function() {
           const t1 = await current.transaction();
+
           const whereValues = {
             json: { some: { input: 'Hello' } }
           };

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -59,7 +59,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 }
               }
             });
-
             if (events.length === 0) {
               await this.Event.create(defaultValues,
                 {

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -28,6 +28,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       if (current.dialect.supports.lock) {
         it('findOrCreate supports transactions, json and locks', async function() {
           const t1 = await current.transaction();
+          // SQL constructs 'FOR UPDATE' with 'FETCH' doesn't work for oracle dialect,
+          // hence use findByPk which doesnt use 'LIMIT; or 'FETCH' in SQL generation
           if (current.options.dialect !== 'oracle') {
             await this.Event.findOrCreate({
               where: {
@@ -71,7 +73,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           const count = await this.Event.count();
           expect(count).to.equal(0);
-          await transaction.commit();
+          await t1.commit();
           const count0 = await this.Event.count();
           expect(count0).to.equal(1);
         });

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -828,8 +828,9 @@ if (current.dialect.supports.transactions) {
           const t1 = await this.sequelize.transaction();
 
           let t1Jan;
-          // SQL constructs 'FOR UPDATE' with 'FETCH' doesn't work for Oracle dialect,
-          // hence use findByPk which doesn't use 'LIMIT' or 'FETCH' in SQL generation
+          // SQL constructs 'FOR UPDATE' with 'FETCH'/'ORDER BY' doesn't work
+          // for Oracle dialect, hence using findByPk just to show the lock
+          // behaviour and it doesn't generate above constructs.
           if (dialect === 'oracle') {
             t1Jan = await User.findByPk(id, { transaction: t1, lock: t1.LOCK.UPDATE });
           } else {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -894,9 +894,9 @@ if (current.dialect.supports.transactions) {
               )
             ]);
 
-            let results;
             const t1 = await this.sequelize.transaction();
 
+            let results;
             if (dialect === 'oracle') {
               results = await User.findByPk(id1.id, { transaction: t1, lock: true });
             } else {
@@ -913,7 +913,9 @@ if (current.dialect.supports.transactions) {
             } else {
               firstUserId = results[0].id;
             }
+
             const t2 = await this.sequelize.transaction();
+
             let secondResults;
             if (dialect === 'oracle') {
               secondResults = await User.findByPk(id2.id, { transaction: t2, lock: true });
@@ -931,6 +933,7 @@ if (current.dialect.supports.transactions) {
             } else {
               secondUserId = secondResults[0].id;
             }
+
             expect(secondUserId).to.not.equal(firstUserId);
 
             await Promise.all([
@@ -959,12 +962,14 @@ if (current.dialect.supports.transactions) {
           await this.sequelize.transaction(t1 => {
 
             if (current.dialect.supports.lockOuterJoinFailure) {
+
               let error;
               if (dialect === 'oracle') {
                 error = 'ORA-02014: cannot select FOR UPDATE from view with DISTINCT, GROUP BY, etc';
               } else {
                 error = 'FOR UPDATE cannot be applied to the nullable side of an outer join';
               }
+
               return expect(User.findOne({
                 where: {
                   username: 'John'

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -827,10 +827,10 @@ if (current.dialect.supports.transactions) {
           const { id } = await User.create({ username: 'jan' });
           const t1 = await this.sequelize.transaction();
 
+          // SQL constructs 'FOR UPDATE' with 'FETCH'/'ORDER BY' throws error,
+          // ORA-02014 for Oracle dialect. Hence using findByPk to test
+          // the lock behaviour.
           let t1Jan;
-          // SQL constructs 'FOR UPDATE' with 'FETCH'/'ORDER BY' doesn't work
-          // for Oracle dialect, hence using findByPk just to show the lock
-          // behaviour and it doesn't generate above constructs.
           if (dialect === 'oracle') {
             t1Jan = await User.findByPk(id, { transaction: t1, lock: t1.LOCK.UPDATE });
           } else {


### PR DESCRIPTION

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

The issue is raised [here](https://github.com/sequelize/sequelize/issues/16606)
- Enabled skipLocked, forShare, lockOuterJoinFailure, lock properties for Oracle dialect. 
-  Oracle does not have shared locks on individual table rows, `FOR UPDATE` is what i found closest to 
 ` forShare` dialect support .
- `FOR UPDATE` cant be used in sql's along with these :
  -  ORDER BY 
  -  FETCH NEXT 1 ROWS ( creates a inline view, ...)

It results in error
`ORA-02014: cannot select FOR UPDATE from view with DISTINCT, GROUP BY, etc. `

We can instead generate a subquery like this , but it's not equivalent and is not correct all the time and might cause issues. 
`SELECT "id", "username", "awesome", "createdAt", "updatedAt" FROM "users"  "user" WHERE  rowid in (select rowid from "users" "user" where "user"."username" = 'jan'  ORDER BY "user"."id" OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) FOR UPDATE;`


Modified tests to use different model API's just to simulate the locking functionality .
-- `findOrCreate` is replaced with `findAll` and `create` 
-- `findByPK` instead of `findByOne`


<!-- Please provide a description of the change here. -->

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
